### PR TITLE
Fix build action (synchronize upload and download actions)

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -128,7 +128,7 @@ jobs:
           touch _gh-pages/.nojekyll
 
       # Save artifact for the next step.
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'push' }}
         with:
           name: gh-pages-build
@@ -146,7 +146,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: ${{ github.event_name == 'push' && ( env.MULTIBRANCH == 'true' || github.ref == format('refs/heads/{0}', env.DEFAULT_BRANCH )) }}
         with:
           name: gh-pages-build


### PR DESCRIPTION
- Unfortunately I hadn't pinned upload-artifact and download-artifact actions consistently, so when there was an update things broke.